### PR TITLE
fix: export parseURN method

### DIFF
--- a/export.js
+++ b/export.js
@@ -4,3 +4,4 @@ export * from './types-dist/LwM2M.js'
 export * from './types-dist/LwM2MDocument.js'
 import schema from './LwM2MDocument.schema.json' assert { type: 'json' }
 export const LwM2MDocumentSchema = schema
+export { parseURN } from './src/type-generation/parseURN.js'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
-export * from './src/type-generation/createURN'
-export * from './src/validate'
-export * from './types/LwM2M'
-export * from './types/LwM2MDocument'
+export * from './src/type-generation/createURN.ts'
+export * from './src/type-generation/parseURN.ts'
+export * from './src/validate.ts'
+export * from './types/LwM2M.ts'
+export * from './types/LwM2MDocument.ts'
 
 export declare const LwM2MDocumentSchema: {
 	$schema: 'http://json-schema.org/draft-07/schema#'


### PR DESCRIPTION
Export  the method in order to be used as a features of the lib.

It deserves to be exported because the URN is created following a set of rules defined by the lib, and by exporting this method the usel will be able to reach out the parts of the URN independent of any update of the rules. Also provides the guarantee of tests already built around the method and its functionality in the project. 